### PR TITLE
bugfix/issue_6 Return All Touch Events

### DIFF
--- a/SdlStreaming/app/src/main/java/com/smartdevicelink/sdlstreaming/sdl/SdlService.java
+++ b/SdlStreaming/app/src/main/java/com/smartdevicelink/sdlstreaming/sdl/SdlService.java
@@ -245,7 +245,7 @@ public class SdlService extends Service implements IProxyListenerALM{
                 public boolean onTouch(View v, MotionEvent event) {
                     Log.d(TAG, "Received motion event on video view");
                     Toast.makeText(v.getContext(),"Touch event received: " + event.getX(),Toast.LENGTH_SHORT).show();
-                    return false;
+                    return true;
                 }
             });
             videoView.setVideoURI(Uri.parse(LOCAL_VIDEO_URI));


### PR DESCRIPTION
Fixes #6 

You must return `true` on onTouch to receive actions past the initial action. For example if the first action is `ACTION_DOWN` and you return false, you will never receive subsequent actions associated with the first, such as `ACTION_MOVE` or `ACTION_UP`