### PR TITLE
Updates for 4.6

### DIFF
--- a/SdlStreaming/app/build.gradle
+++ b/SdlStreaming/app/build.gradle
@@ -23,10 +23,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.smartdevicelink:sdl_android:4.+'
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'com.smartdevicelink:sdl_android:4.+'
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }

--- a/SdlStreaming/app/proguard-rules.pro
+++ b/SdlStreaming/app/proguard-rules.pro
@@ -8,6 +8,8 @@
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
 # Add any project specific keep options here:
+-keep class com.smartdevicelink.** { *; }
+-keep class com.livio.** { *; }
 
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface

--- a/SdlStreaming/app/src/main/AndroidManifest.xml
+++ b/SdlStreaming/app/src/main/AndroidManifest.xml
@@ -54,8 +54,6 @@
             <intent-filter>
                 <action android:name="com.smartdevicelink.USB_ACCESSORY_ATTACHED" />
                 <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
-                <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
-                <action android:name="android.media.AUDIO_BECOMING_NOISY" />
                 <action android:name="sdl.router.startservice" />
             </intent-filter>
         </receiver>


### PR DESCRIPTION
-Change `compile` to `implementation` and use version 4.+
-Add proguard rules
-Remove unused intent filters